### PR TITLE
Update Description and modify Wants

### DIFF
--- a/demandshaper.service
+++ b/demandshaper.service
@@ -38,10 +38,10 @@
 ###
 
 [Unit]
-Description=Emoncms MQTT Input Script
-Wants=mosquitto.service mysql.service redis.service
-After=mosquitto.service mysql.service redis.service
-Documentation=https://github.com/emoncms/demandshaper.git
+Description=Emoncms Demandshaper service
+Wants=mysql.service redis.service
+After=mysql.service redis.service
+Documentation=https://github.com/emoncms/demandshaper/blob/master/readme.md
 
 # Uncomment this line to use a dedicated log file for StdOut and StdErr.
 # NOTE: only works in systemd v236+


### PR DESCRIPTION
1.  Updated the Description!
2.  Updated Wants and After to remove `mosquitto` - the **service** does not in itself depend on mosquitto being installed locally. Wanting this can cause issues with systems that run mosquitto in a different server.  If this is required for the EmonSD type installs, a drop in should be created and linked to.
3.  Updated Documentation link.