### PR TITLE
Set demandshaper EV state of charge from emoncms input

### DIFF
--- a/demandshaper-module/battery.js
+++ b/demandshaper-module/battery.js
@@ -22,6 +22,7 @@ var battery = {
     end_soc: 0.8,
     capacity: 20.0,
     charge_rate: 3.8,
+    events_loaded: false,
 
     init: function(element) {
         battery.element = element;
@@ -34,6 +35,7 @@ var battery = {
         $("#"+element).attr("width",battery.width);
         $("#"+element).attr("height",battery.height);
 
+        if (!battery.events_loaded) battery.events();
     },
     
     draw: function() {
@@ -105,7 +107,7 @@ var battery = {
     },
     
     events: function() {
-    
+        battery.events_loaded = true;
         element = "#"+battery.element;
     
         $(element).mousedown(function( event ) {

--- a/demandshaper-module/battery.js
+++ b/demandshaper-module/battery.js
@@ -23,6 +23,8 @@ var battery = {
     capacity: 20.0,
     charge_rate: 3.8,
     events_loaded: false,
+    balpercentage: 1,
+    baltime: 0,
 
     init: function(element) {
         battery.element = element;
@@ -94,6 +96,13 @@ var battery = {
         
         var kwh = (battery.end_soc - battery.soc) * battery.capacity;
         var time_left = kwh / battery.charge_rate;
+        console.log("Time Left: " + time_left);
+        // Add on balancing time if balancing percentage is lower than end SOC
+        if (battery.balpercentage < battery.end_soc) {
+            time_left += battery.baltime;
+            console.log("Balancing required Time to be added: " + battery.baltime + " - New Time Left: " + time_left);
+        }
+        
         battery.period = time_left;
         
         var h = Math.floor(time_left);

--- a/demandshaper-module/demandshaper_model.php
+++ b/demandshaper-module/demandshaper_model.php
@@ -155,4 +155,5 @@ class DemandShaper
             "energylocal_bethesda"=>array("category"=>"Energy Local","name"=>"Bethesda")
         );
     }
+
 }

--- a/demandshaper-module/general.js
+++ b/demandshaper-module/general.js
@@ -179,23 +179,27 @@ function load_device(device_id, device_name, device_type)
             setTimeout(function(){
                 if (((new Date()).getTime()-last_submit)>1900) {
                     submit_schedule(1,function(result){
-                        console.log("saved");
-                        
-                        // Check result
-                        if (js_calc) {
-                            if (JSON.stringify(result.schedule.runtime.periods)==JSON.stringify(schedule.runtime.periods)) { 
-                                console.log("php js schedule match"); 
-                            } else { 
-                                console.log("php js schedule match error")
-                                console.log("php: "+JSON.stringify(result.schedule.runtime.periods))
-                                console.log("js:  "+JSON.stringify(schedule.runtime.periods))
+                        if (result.schedule!=undefined) {
+                            console.log("saved");
+                            
+                            // Check result
+                            if (js_calc) {
+                                if (JSON.stringify(result.schedule.runtime.periods)==JSON.stringify(schedule.runtime.periods)) { 
+                                    console.log("php js schedule match"); 
+                                } else { 
+                                    console.log("php js schedule match error")
+                                    console.log("php: "+JSON.stringify(result.schedule.runtime.periods))
+                                    console.log("js:  "+JSON.stringify(schedule.runtime.periods))
+                                }
+                            } else {
+                                schedule.runtime.periods = result.schedule.runtime.periods
                             }
+                            
+                            clearTimeout(get_device_state_timeout)
+                            get_device_state_timeout = setTimeout(function(){ get_device_state(); },1000);
                         } else {
-                            schedule.runtime.periods = result.schedule.runtime.periods
+                            console.log(result);
                         }
-                        
-                        clearTimeout(get_device_state_timeout)
-                        get_device_state_timeout = setTimeout(function(){ get_device_state(); },1000);
                     });
                 }
             },2000);
@@ -644,6 +648,8 @@ function load_device(device_id, device_name, device_type)
             schedule.settings[name] -= resolution_hours;
             if (schedule.settings[name]<0.0) schedule.settings[name] = 24.0-resolution_hours;
         }
+        
+        if (name=="period") schedule.runtime.timeleft = schedule.settings.period * 3600;
         calc_schedule();
     });
 
@@ -658,6 +664,8 @@ function load_device(device_id, device_name, device_type)
         hour = Math.round(hour/resolution_hours)*resolution_hours
         
         schedule.settings[name] = hour
+        
+        if (name=="period") schedule.runtime.timeleft = schedule.settings.period * 3600;
         calc_schedule(); 
     });
 

--- a/demandshaper-module/general.js
+++ b/demandshaper-module/general.js
@@ -39,6 +39,8 @@ function load_device(device_id, device_name, device_type)
             chargerate: 3.8,
             ovms_vehicleid: '',
             ovms_carpass: '',
+            balpercentage: '',
+            baltime: '',
             ev_soc: 0.2,
             ev_target_soc: 0.8,
             ip: ''
@@ -125,7 +127,7 @@ function load_device(device_id, device_name, device_type)
                 
                 if (schedule.settings.device_type=="openevse" && schedule.settings.openevsecontroltype=='socovms') {
                     if (schedule.settings.ovms_vehicleid!='' && schedule.settings.ovms_carpass!='') {
-                        $.ajax({ url: emoncmspath+"demandshaper/ovms?vehicleid="+schedule.settings.ovms_vehicleid+"&carpass="+schedule.settings.ovms_carpass+apikeystr, dataType: 'json', async: true, success: function(result) {
+                        $.ajax({ url: emoncmspath+"demandshaper/ovms?vehicleid="+schedule.settings.ovms_vehicleid+"&carpass="+schedule.settings.ovms_carpass+apikeystr, dataType: 'json', async: true, 
                             schedule.settings.ev_soc = result.soc*0.01;
                             schedule.settings.period = ((schedule.settings.ev_target_soc-schedule.settings.ev_soc)*schedule.settings.batterycapacity)/schedule.settings.chargerate;
                             if (schedule.settings.ev_soc!=last_ev_soc) calc_schedule();                     
@@ -266,6 +268,8 @@ function load_device(device_id, device_name, device_type)
             $(".input[name=openevsecontroltype]").val(schedule.settings.openevsecontroltype);
             $(".input[name=batterycapacity]").val(schedule.settings.batterycapacity);
             $(".input[name=chargerate]").val(schedule.settings.chargerate);
+            $(".input[name=balpercentage").val(schedule.settings.balpercentage * 100);
+            $(".input[name=baltime").val(Math.round(schedule.settings.baltime * 60));
             
             if (schedule.settings.openevsecontroltype=="socinput" || schedule.settings.openevsecontroltype=="socovms") {
             
@@ -273,7 +277,12 @@ function load_device(device_id, device_name, device_type)
                 battery.charge_rate = schedule.settings.chargerate;
                 battery.end_soc = schedule.settings.ev_target_soc;
                 battery.soc = schedule.settings.ev_soc;
-                       
+
+                if (schedule.settings.balpercentage >=0 && schedule.settings.balpercentage <= 1) {
+                    battery.balpercentage = schedule.settings.balpercentage;
+                    battery.baltime = schedule.settings.baltime;
+                }
+
                 $("#battery_bound").show();
                 battery.init("battery");
                 battery.draw();
@@ -293,7 +302,6 @@ function load_device(device_id, device_name, device_type)
             } else {
                 $(".ovms-options").hide();
             }
-           
         }
     }
 
@@ -702,7 +710,12 @@ function load_device(device_id, device_name, device_type)
         battery.period = Math.round(battery.period/resolution_hours)*resolution_hours
         schedule.settings.period = battery.period
         schedule.settings.ev_target_soc = battery.end_soc
-        schedule.runtime.timeleft = schedule.settings.period * 3600
+        if (schedule.settings.balpercentage < schedule.settings.ev_target_soc) {
+            schedule.runtime.timeleft = (schedule.settings.period + schedule.settings.baltime) * 3600;
+        }
+        else {
+            schedule.runtime.timeleft = schedule.settings.period * 3600;
+        }
         
         if (mode=="on") {
             var now = new Date();
@@ -761,6 +774,19 @@ function load_device(device_id, device_name, device_type)
         schedule.settings.ovms_carpass = carpass;
         calc_schedule();
     });
+
+    $(".input[name=balpercentage").change(function(){
+        var balpercentage = $(this).val();
+        schedule.settings.balpercentage = (balpercentage * 0.01);
+        calc_schedule();
+    });
+
+    $(".input[name=baltime").change(function(){
+        var baltime = $(this).val();
+        schedule.settings.baltime = baltime / 60;
+        calc_schedule();
+    });
+
     // ------------------------------------------------
     
     $("#delete-device-confirm").click(function(){

--- a/demandshaper-module/general.php
+++ b/demandshaper-module/general.php
@@ -16,7 +16,7 @@
           
           <div class="openevse hide">
             <p>Charge Current <span id="charge_current">0</span>A<br><span style="font-weight:normal; font-size:12px">Temperature <span id="openevse_temperature">10</span>C</span></p>
-            <div id="battery_bound" style="width:100%">
+            <div id="battery_bound" style="width:100%" class="hide">
                 <canvas id="battery"></canvas>
             </div>
           </div>
@@ -137,10 +137,13 @@
             <br>
             <table style="width:100%; text-align:left">
               <tr>
+                <td><span class="">Control based on: </span></td><td><select class="input" name="openevsecontroltype"><option value="time">Charge time</option><!--<option value="energy">Charge energy</option><option value="miles">Travel distance</option>--><option value="socinput">Battery charge level (Input)</option><option value="socovms">Battery charge level (OVMS)</option></select></td>
+              </tr>
+              <tr>
                 <td><span class="">Useable Battery Capacity: </span></td><td><input class="input" name="batterycapacity" type="text" style="width:80px"/> kWh</td>
                 <td><span class="">EVSE Charge Rate: </span></td><td><input class="input" name="chargerate" type="text" style="width:80px"/> kW</td>
               </tr>
-              <tr>
+              <tr class="ovms-options hide">
                 <td><span class="">OVMS Vehicle ID: </span></td><td><input class="input" name="vehicleid" type="text" style="width:150px"/></td>
                 <td><span class="">OVMS Car Password: </span></td><td><input class="input" name="carpass" type="text" style="width:150px"/></td>
               </tr>

--- a/demandshaper-module/general.php
+++ b/demandshaper-module/general.php
@@ -143,7 +143,7 @@
                 <td><span class="">Useable Battery Capacity: </span></td><td><input class="input" name="batterycapacity" type="text" style="width:80px"/> kWh</td>
                 <td><span class="">EVSE Charge Rate: </span></td><td><input class="input" name="chargerate" type="text" style="width:80px"/> kW</td>
               </tr>
-              <tr>
+              <tr class="openevse-balancing hide">
                 <td><span class="">Balancing Percentage: </span></td><td><input class="input" name="balpercentage" type="text" style="width:80px"/> %</td>
                 <td><span class="">Balancing Time: </span></td><td><input class="input" name="baltime" type="text" style="width:80px"/> Mins</td>
               </tr>

--- a/demandshaper-module/general.php
+++ b/demandshaper-module/general.php
@@ -143,6 +143,10 @@
                 <td><span class="">Useable Battery Capacity: </span></td><td><input class="input" name="batterycapacity" type="text" style="width:80px"/> kWh</td>
                 <td><span class="">EVSE Charge Rate: </span></td><td><input class="input" name="chargerate" type="text" style="width:80px"/> kW</td>
               </tr>
+              <tr>
+                <td><span class="">Balancing Percentage: </span></td><td><input class="input" name="balpercentage" type="text" style="width:80px"/> %</td>
+                <td><span class="">Balancing Time: </span></td><td><input class="input" name="baltime" type="text" style="width:80px"/> Mins</td>
+              </tr>
               <tr class="ovms-options hide">
                 <td><span class="">OVMS Vehicle ID: </span></td><td><input class="input" name="vehicleid" type="text" style="width:150px"/></td>
                 <td><span class="">OVMS Car Password: </span></td><td><input class="input" name="carpass" type="text" style="width:150px"/></td>

--- a/demandshaper-module/view.php
+++ b/demandshaper-module/view.php
@@ -16,7 +16,7 @@ global $path;
 $device = "";
 if (isset($_GET['device'])) $device = $_GET['device'];
 
-$v=11;
+$v=12;
 
 $emoncmspath = $path;
 if ($remoteaccess) $emoncmspath .= "remoteaccess/";


### PR DESCRIPTION
Option to set EV SOC from emoncms input, this opens up possibility of providing SOC via either MQTT or HTTP

![image](https://user-images.githubusercontent.com/503186/73314174-0ac30e80-4225-11ea-94ce-3bcea83ad14a.png)

Update SOC with HTTP

    /input/post?node=openevse&data=soc:25

Update SOC with MQTT:

    topic: emon/openevse/soc
    value: 25