### PR TITLE
Added support for setting Smart Target SoC via EmonCMS Input

### DIFF
--- a/devices/openevse.php
+++ b/devices/openevse.php
@@ -159,6 +159,10 @@ class openevse
                     $schedule->settings->current_soc = $input->get_last_value($feedid)*0.01;
                     schedule_log("Recalculating EVSE schedule based on emoncms input: ".$schedule->settings->current_soc);
                 }
+                if ($feedid = $input->exists_nodeid_name($userid,"openevse","target_soc")) {
+                    $schedule->settings->target_soc = $input->get_last_value($feedid)*0.01;
+                    schedule_log("Recalculating EVSE schedule based on emoncms target soc input: ".$schedule->settings->target_soc);
+                }
             }
             else if ($schedule->settings->soc_source=='ovms') {
                 if ($schedule->settings->ovms_vehicleid!='' && $schedule->settings->ovms_carpass!='') {
@@ -168,7 +172,7 @@ class openevse
                     schedule_log("Recalculating EVSE schedule based on ovms: ".$schedule->settings->current_soc);
                 }
             }
-            $kwh_required = ($schedule->settings->target_soc-$schedule->settings->current_soc)*$schedule->settings->battery_capacity;
+            $kwh_required = max(($schedule->settings->target_soc-$schedule->settings->current_soc)*$schedule->settings->battery_capacity,0);
             $schedule->settings->period = $kwh_required/$schedule->settings->charge_rate;      
             
             if (isset($schedule->settings->balpercentage) && $schedule->settings->balpercentage < $schedule->settings->target_soc) {

--- a/devices/openevse.php
+++ b/devices/openevse.php
@@ -157,7 +157,7 @@ class openevse
                 global $input;
                 if ($feedid = $input->exists_nodeid_name($userid,"openevse","soc")) {
                     $schedule->settings->current_soc = $input->get_last_value($feedid)*0.01;
-                    schedule_log("Recalculating EVSE schedule based on emoncms input: ".$schedule->settings->current_soc);
+                    schedule_log("Recalculating EVSE schedule based on emoncms current soc input: ".$schedule->settings->current_soc);
                 }
                 if ($feedid = $input->exists_nodeid_name($userid,"openevse","target_soc")) {
                     $schedule->settings->target_soc = $input->get_last_value($feedid)*0.01;


### PR DESCRIPTION
Similar to setting current SoC via input, this allows the target SoC to be dynamically updated. For example to allow pushing a new value via MQTT from Home Assistant & TeslaMate. 

Means that the user can just set their target SoC on the Tesla app as they naturally would, and let TeslaMate & Home Assistant push it to Demand Shaper - removing the need for the user to have to match Demand Shaper's target SoC each time. Also ensures that if there were a delta between the car's target SoC & Demand Shaper that the car's target always wins, so that the schedule can be set accordingly for best pricing.